### PR TITLE
agent-alpine: use full-featured lspci instead of busybox lspci

### DIFF
--- a/puppet-agent-alpine/Dockerfile
+++ b/puppet-agent-alpine/Dockerfile
@@ -5,7 +5,13 @@ ENV PUPPET_VERSION="4.5.1" FACTER_VERSION="2.4.6"
 
 LABEL com.puppet.version=$PUPPET_VERSION com.puppet.git.repo="https://github.com/puppetlabs/dockerfiles" com.puppet.git.sha="093132b2d0bc766a55c7820fab69d7bcd945aeb6" com.puppet.buildtime="2016-06-03T08:39:36Z" com.puppet.dockerfile="/Dockerfile"
 
-RUN apk add --update ruby ruby-rdoc ruby-irb ca-certificates && \
+RUN apk add --update \
+      ca-certificates \
+      pciutils \
+      ruby \
+      ruby-irb \
+      ruby-rdoc \
+      && \
     echo http://dl-4.alpinelinux.org/alpine/edge/testing/ >> /etc/apk/repositories && \
     apk add --update shadow && \
     rm -rf /var/cache/apk/* && \


### PR DESCRIPTION
This is the version from http://mj.ucw.cz/pciutils.html
that also includes PCI ID's packaged for Alpine at
https://pkgs.alpinelinux.org/package/v3.4/main/x86_64/pciutils

It aligns with `lspci` from distros other than Alpine and
ensures facts are consistent across distros.

The goal is to ensure that facter facts (source)  are homogeneous
across distros.

Also: put one package per line to avoid future diff churn.