### PR TITLE
puppetdb, puppetserver: Add volumes for persistent cert storage

### DIFF
--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -32,6 +32,11 @@ COPY logging /etc/puppetlabs/puppetdb/logging
 RUN rm -fr /etc/puppetlabs/puppetdb/conf.d
 COPY conf.d /etc/puppetlabs/puppetdb/conf.d
 
+# Persist the agent SSL certificate.
+VOLUME /etc/puppetlabs/puppet/ssl/
+# /etc/puppetlabs/puppetdb/ssl is automatically populated from here and
+# doesn't need a separate volume.
+
 COPY docker-entrypoint.sh /
 
 EXPOSE 8080 8081

--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -32,7 +32,9 @@ COPY request-logging.xml /etc/puppetlabs/puppetserver/
 
 RUN puppet config set autosign true --section master
 
-VOLUME /etc/puppetlabs/code/
+VOLUME /etc/puppetlabs/code/ \
+       /etc/puppetlabs/puppet/ssl/ \
+       /opt/puppetlabs/server/data/puppetserver/
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
As discussed in #13, define some persistent volumes.
