### PR TITLE
Install r10k in puppetserver image

### DIFF
--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install --no-install-recommends -y puppetserver="$PUPPET_SERVER_VERSION"-1puppetlabs1 && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    gem install --no-rdoc --no-ri r10k
 
 COPY puppetserver /etc/default/puppetserver
 COPY logback.xml /etc/puppetlabs/puppetserver/


### PR DESCRIPTION
Use r10k to handle puppet modules (within the docker environment). 

You can use it with for example:

`docker exec -it puppet bash -c 'cd /etc/puppetlabs/code/environments/production && r10k puppetfile install'`

also using `--entrypoint r10k` should be possible

An alternative approach would be an extra image which only holds r10k binary.
If you prefer an extra image please let me know - I can create a pull request for this as well. 
