### PR TITLE
Set the certname to the hostname

### DIFF
--- a/puppetdb/docker-entrypoint.sh
+++ b/puppetdb/docker-entrypoint.sh
@@ -5,6 +5,7 @@ if [ ! -d "/etc/puppetlabs/puppetdb/ssl" ]; then
     sleep 1
   done
   set -e
+  /opt/puppetlabs/bin/puppet config set certname ${HOSTNAME}
   /opt/puppetlabs/bin/puppet agent --verbose --onetime --no-daemonize --waitforcert 120
   /opt/puppetlabs/server/bin/puppetdb ssl-setup -f
 fi


### PR DESCRIPTION
Ensures that puppetdb is creating a hostname that is usable when
creating an environment form docker-compose