### PR TITLE
Fixed permissions error on first start of puppetmaster with dir /opt/…

### DIFF
--- a/puppetserver-standalone/docker-entrypoint.sh
+++ b/puppetserver-standalone/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 chown -R puppet:puppet /etc/puppetlabs/puppet/ssl
+chown -R puppet:puppet /opt/puppetlabs/server/data/puppetserver/
 
 if test -n "${PUPPETDB_SERVER_URLS}" ; then
   sed -i "s@^server_urls.*@server_urls = ${PUPPETDB_SERVER_URLS}@" /etc/puppetlabs/puppet/puppetdb.conf


### PR DESCRIPTION
Fixed permissions error on first start of puppetmaster with dir /opt/puppetlabs/server/data/puppetserver

ERROR [puppetserver] Puppet Could not set 'directory' on ensure: Permission denied - /opt/puppetlabs/server/data/puppetserver/state