### PR TITLE
Cut down the number of directories in VOLUME.

### DIFF
--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -33,9 +33,7 @@ COPY request-logging.xml /etc/puppetlabs/puppetserver/
 
 RUN puppet config set autosign true --section master
 
-VOLUME /etc/puppetlabs/code/ \
-       /etc/puppetlabs/puppet/ssl/ \
-       /opt/puppetlabs/server/data/puppetserver/
+VOLUME /etc/puppetlabs/puppet/ssl/
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
VOLUME makes it impossible to add additional data to that directory
while building downstream docker image.

There is a 3 year old docker bug about that (see below) and I really
like the following advise:

Basically, don't declare VOLUME unless you are done with that directory.

https://github.com/docker/docker/issues/3639#issuecomment-162872954

In particular, culprit for me is
/opt/puppetlabs/server/data/puppetserver/ where I want to install
additional gems. For all kinds and purposes, the only VOLUME here is
ssldir (and maybe code to some extent). But since volumes can be defined
at run time (and mostly everybody would do it anyway), I would just
remove the VOLUME directive completely if I were you.

The problem was introduced by PR
https://github.com/puppetlabs/puppet-in-docker/pull/15 (author @ms1111)