### PR TITLE
Improve facter OS facts

### DIFF
--- a/puppet-agent-ubuntu/Dockerfile
+++ b/puppet-agent-ubuntu/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
     rm puppetlabs-release-pc1-"$UBUNTU_CODENAME".deb && \
     apt-get update && \
     apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$UBUNTU_CODENAME" && \
-    apt-get remove --purge -y lsb-release wget && \
+    apt-get remove --purge -y wget && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/puppet-agent-ubuntu/spec/dockerfile_spec.rb
+++ b/puppet-agent-ubuntu/spec/dockerfile_spec.rb
@@ -5,14 +5,14 @@ CURRENT_DIRECTORY = File.dirname(File.dirname(__FILE__))
 describe 'Dockerfile' do
   include_context 'with a docker image'
 
-  describe package('puppet-agent') do
-    it { is_expected.to be_installed }
+  ['puppet-agent', 'lsb-release'].each do |package_name|
+    describe package(package_name) do
+      it { is_expected.to be_installed }
+    end
   end
 
-  ['wget', 'lsb-release'].each do |package_name|
-    describe package(package_name) do
-      it { is_expected.not_to be_installed }
-    end
+  describe package('wget') do
+    it { is_expected.not_to be_installed }
   end
 
   describe file('/opt/puppetlabs/bin/puppet') do


### PR DESCRIPTION
This commit leaves lsb_release installed so that facter is able to
correctly identify information about the OS distro.