### PR TITLE
Add PUPPETDB_DATABASE_HOST and PUPPETDB_DATABASE

### DIFF
--- a/puppetdb/conf.d/database.conf
+++ b/puppetdb/conf.d/database.conf
@@ -1,7 +1,7 @@
 database: {
   classname: org.postgresql.Driver
   subprotocol: postgresql
-  subname: "//postgres:5432/puppetdb"
+  subname: "//${PUPPETDB_DATABASE_HOST:-postgres}:5432/${PUPPETDB_DATABASE:-puppetdb}"
   username: ${PUPPETDB_USER}
   password: ${PUPPETDB_PASSWORD}
   log-slow-statements: 10


### PR DESCRIPTION
Adding PUPPETDB_DATABASE_HOST and PUPPETDB_DATABASE variables into the configuration. This should allow for overriding without of both the database and host for postgresql without changing the defaults.