### PR TITLE
Allow subname to be specified as an env var

### DIFF
--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Gareth Rushgrove "gareth@puppet.com"
 
-ENV PUPPETDB_VERSION="4.3.0" PUPPET_AGENT_VERSION="1.8.3" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_SUBNAME="//postgres:5432/puppetdb" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PUPPETDB_VERSION="4.3.0" PUPPET_AGENT_VERSION="1.8.3" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_DATABASE_CONNECTION="//postgres:5432/puppetdb" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \

--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Gareth Rushgrove "gareth@puppet.com"
 
-ENV PUPPETDB_VERSION="4.3.0" PUPPET_AGENT_VERSION="1.8.3" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PUPPETDB_VERSION="4.3.0" PUPPET_AGENT_VERSION="1.8.3" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_SUBNAME="//postgres:5432/puppetdb" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \

--- a/puppetdb/conf.d/database.conf
+++ b/puppetdb/conf.d/database.conf
@@ -1,7 +1,7 @@
 database: {
   classname: org.postgresql.Driver
   subprotocol: postgresql
-  subname: "//postgres:5432/puppetdb"
+  subname: ${PUPPETDB_SUBNAME}
   username: ${PUPPETDB_USER}
   password: ${PUPPETDB_PASSWORD}
   log-slow-statements: 10

--- a/puppetdb/conf.d/database.conf
+++ b/puppetdb/conf.d/database.conf
@@ -1,7 +1,7 @@
 database: {
   classname: org.postgresql.Driver
   subprotocol: postgresql
-  subname: ${PUPPETDB_SUBNAME}
+  subname: ${PUPPETDB_DATABASE_CONNECTION}
   username: ${PUPPETDB_USER}
   password: ${PUPPETDB_PASSWORD}
   log-slow-statements: 10


### PR DESCRIPTION
In case we need to specify a different host/port/database for PostgreSQL.

Ex:
```
PUPPEDB_SUBNAME='//1234.5678.us-east-1.rds.amazonaws.com:5432/puppetdb'
```