### PR TITLE
Do not force volume creation

### DIFF
--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -33,10 +33,6 @@ COPY request-logging.xml /etc/puppetlabs/puppetserver/
 
 RUN puppet config set autosign true --section master
 
-VOLUME /etc/puppetlabs/code/ \
-       /etc/puppetlabs/puppet/ssl/ \
-       /opt/puppetlabs/server/data/puppetserver/
-
 COPY docker-entrypoint.sh /
 
 EXPOSE 8140


### PR DESCRIPTION
Do not force the creation of volumes.

As per https://docs.docker.com/engine/reference/builder/#volume
> Changing the volume from within the Dockerfile: If any build steps change the data within the volume after it has been declared, those changes will be discarded.

This means that if someone tries to create a child docker image of this project. Anything that would be put into `/etc/puppetlabs/code/` (or `/etc/puppetlabs/puppet/ssl/` or `/opt/puppetlabs/server/data/puppetserver/`) would be discared.

As far as I can tell there is no reason for those to be declared as volumes. They can be declared at runtime as volume if a user wants to, but otherwise this seems to do more harm than good :(

Relates to moby/moby#8177