### PR TITLE
Add health check for Puppet Server

### DIFF
--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Gareth Rushgrove "gareth@puppet.com"
 
-ENV PUPPET_SERVER_VERSION="2.7.2" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PUPPET_SERVER_VERSION="2.7.2" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
@@ -50,7 +50,7 @@ HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
   --cert   $(puppet config print hostcert) \
   --key    $(puppet config print hostprivkey) \
   --cacert $(puppet config print localcacert) \
-  https://puppet:8140/production/status/test \
+  https://puppet:8140/${PUPPET_HEALTHCHECK_ENVIRONMENT}/status/test \
   |  grep -q '"is_alive":true' \
   || exit 1
 

--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -44,4 +44,14 @@ EXPOSE 8140
 ENTRYPOINT ["dumb-init", "/docker-entrypoint.sh"]
 CMD ["foreground" ]
 
+HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
+  curl --fail -H 'Accept: pson' \
+  --resolve 'puppet:8140:127.0.0.1' \
+  --cert   $(puppet config print hostcert) \
+  --key    $(puppet config print hostprivkey) \
+  --cacert $(puppet config print localcacert) \
+  https://puppet:8140/production/status/test \
+  |  grep -q '"is_alive":true' \
+  || exit 1
+
 COPY Dockerfile /


### PR DESCRIPTION
This PR adds a health check for the Puppet Server (addresses #37).
It uses the latest version of the Puppet HTTP API, and it is authenticated by it's own certificates.

The `--resolve 'puppet:8140:127.0.0.1'` is a workaround for dynamic hostnames. This workaround just creates a new route for `puppet` to `127.0.0.1` without the need to modify the system or call docker with extra parameters.

If no hostname is declared (or one that does not have a domain), puppet appends `.local` to the docker hostname. So a curl call to `https://$(hostname):8140/production/status/test` would fail with a certificate mismatch (between `a56a322f2572.local` and `a56a322f2572`). On the other hand, if a hostname is specified, then just calling `https://puppet:8140/production/status/test` will fail because `puppet` is not resolved in `/etc/hosts`. 

```
$ puppet cert list --all
+ "a56a322f2572.local" (SHA256) A9:FA:66:A9:AB:85:9F:F5:5C:2B:9B:27:35:73:B1:D3:EC:27:DA:D8:80:5F:EE:C5:9E:DE:ED:DD:33:00:E6:B5 (alt names: "DNS:puppet", "DNS:a56a322f2572.local")
```