### PR TITLE
Update puppet to puppetdb to 4.4.0 and agent version to 1.10.1

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,9 @@ Metrics/LineLength:
 
 Metrics/BlockLength:
   Max: 100
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ desc 'List all Docker images along with some data about them'
 task :list do
   images = IMAGES.collect do |name|
     sha = get_vcs_ref_from_label(name)
-    sha = Rainbow(sha).yellow unless sha == current_git_sha || sha == previous_git_sha
+    sha = Rainbow(sha).yellow unless [current_git_sha, previous_git_sha].include? sha
     {
       name: name,
       version: get_version_from_label(name),

--- a/puppetdb-postgres/Dockerfile
+++ b/puppetdb-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.5.3
+FROM postgres:9.6.3
 MAINTAINER Gareth Rushgrove "gareth@puppet.com"
 
 LABEL org.label-schema.vendor="Puppet" \

--- a/puppetdb-postgres/spec/dockerfile_spec.rb
+++ b/puppetdb-postgres/spec/dockerfile_spec.rb
@@ -9,11 +9,11 @@ describe 'Dockerfile' do
     it { is_expected.to be_installed }
   end
 
-  describe package('postgresql-9.5') do
+  describe package('postgresql-9.6') do
     it { is_expected.to be_installed }
   end
 
-  describe package('postgresql-contrib-9.5') do
+  describe package('postgresql-contrib-9.6') do
     it { is_expected.to be_installed }
   end
 

--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Gareth Rushgrove "gareth@puppet.com"
 
-ENV PUPPETDB_VERSION="4.3.0" PUPPET_AGENT_VERSION="1.8.3" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PUPPETDB_VERSION="4.4.0" PUPPET_AGENT_VERSION="1.10.1" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \


### PR DESCRIPTION
I ran into some troubles using postgres 9.5 in docker swarm with overlay.  I upgraded to postgres 9.6 and got a new version of puppetdb, which was my first attempt at debugging this issue.

So far the number of connections are not growing.  You have to delete the postgres db 9.6 data in this solution, i'm not sure what the best solution to upgrade the db files from 9.5 to 9.6.

