### PR TITLE
Allow configuration through environment variables

### DIFF
--- a/puppetboard/Dockerfile
+++ b/puppetboard/Dockerfile
@@ -27,6 +27,6 @@ EXPOSE $PUPPETBOARD_PORT
 
 WORKDIR /var/www/puppetboard
 
-CMD /usr/bin/gunicorn -b 0.0.0.0:${PUPPETBOARD_PORT} wsgi:application
+CMD /usr/bin/gunicorn -b 0.0.0.0:${PUPPETBOARD_PORT} --access-logfile=/dev/stdout wsgi:application
 
 COPY Dockerfile /

--- a/puppetboard/Dockerfile
+++ b/puppetboard/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.4
 MAINTAINER Gareth Rushgrove "gareth@puppet.com"
 
-ENV PUPPET_BOARD_VERSION="0.2.0" GUNICORN_VERSION="19.6.0"
+ENV PUPPET_BOARD_VERSION="0.2.0" \
+    GUNICORN_VERSION="19.6.0" \ 
+    PUPPETBOARD_PORT="8000"
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
@@ -19,13 +21,12 @@ RUN apk add --no-cache --update py-pip && \
 
 RUN pip install puppetboard=="$PUPPET_BOARD_VERSION" gunicorn=="$GUNICORN_VERSION"
 
-COPY wsgi.py /var/www/puppetboard/
-COPY settings.py /var/www/puppetboard/
+COPY wsgi.py settings.py /var/www/puppetboard/
 
-EXPOSE 8000
+EXPOSE $PUPPETBOARD_PORT
 
 WORKDIR /var/www/puppetboard
 
-CMD ["/usr/bin/gunicorn", "-b", "0.0.0.0:8000", "wsgi:application"]
+CMD /usr/bin/gunicorn -b 0.0.0.0:${PUPPETBOARD_PORT} wsgi:application
 
 COPY Dockerfile /

--- a/puppetboard/settings.py
+++ b/puppetboard/settings.py
@@ -1,39 +1,76 @@
 import os
 
-PUPPETDB_HOST = 'puppetdb'
-PUPPETDB_PORT = 8080
-PUPPETDB_SSL_VERIFY = False
-PUPPETDB_KEY = None
-PUPPETDB_CERT = None
-PUPPETDB_TIMEOUT = 20
-DEFAULT_ENVIRONMENT = 'production'
-SECRET_KEY = os.urandom(24)
-DEV_LISTEN_HOST = '127.0.0.1'
-DEV_LISTEN_PORT = 5000
-DEV_COFFEE_LOCATION = 'coffee'
-UNRESPONSIVE_HOURS = 2
-ENABLE_QUERY = True
-LOCALISE_TIMESTAMP = True
-LOGLEVEL = 'info'
-REPORTS_COUNT = 10
-OFFLINE_MODE = False
-ENABLE_CATALOG = True
-GRAPH_FACTS = ['architecture',
-               'clientversion',
-               'domain',
-               'lsbcodename',
-               'lsbdistcodename',
-               'lsbdistid',
-               'lsbdistrelease',
-               'lsbmajdistrelease',
-               'netmask',
-               'osfamily',
-               'puppetversion',
-               'processorcount']
-INVENTORY_FACTS = [ ('Hostname',       'fqdn'              ),
-                    ('IP Address',     'ipaddress'         ),
-                    ('OS',             'lsbdistdescription'),
-                    ('Architecture',   'hardwaremodel'     ),
-                    ('Kernel Version', 'kernelrelease'     ),
-                    ('Puppet Version', 'puppetversion'     ), ]
-REFRESH_RATE = 30
+PUPPETDB_HOST = os.getenv('PUPPETDB_HOST', 'puppetdb')
+PUPPETDB_PORT = int(os.getenv('PUPPETDB_PORT', '8080'))
+# Since this is an env it will alwas be a string, we need
+# to conver that string to a bool
+SSL_VERIFY = os.getenv('PUPPETDB_SSL_VERIFY', 'True')
+if SSL_VERIFY.upper() == 'TRUE':
+    PUPPETDB_SSL_VERIFY = True
+elif SSL_VERIFY.upper() == 'FALSE':
+    PUPPETDB_SSL_VERIFY = False
+else:
+    PUPPETDB_SSL_VERIFY = SSL_VERIFY
+
+PUPPETDB_KEY = os.getenv('PUPPETDB_KEY', None)
+PUPPETDB_CERT = os.getenv('PUPPETDB_CERT', None)
+PUPPETDB_TIMEOUT = int(os.getenv('PUPPETDB_TIMEOUT', '20'))
+DEFAULT_ENVIRONMENT = os.getenv('DEFAULT_ENVIRONMENT', 'production')
+SECRET_KEY = os.getenv('SECRET_KEY', os.urandom(24))
+DEV_LISTEN_HOST = os.getenv('DEV_LISTEN_HOST', '127.0.0.1')
+DEV_LISTEN_PORT = int(os.getenv('DEV_LISTEN_PORT', '5000'))
+DEV_COFFEE_LOCATION = os.getenv('DEV_COFFEE_LOCATION', 'coffee')
+UNRESPONSIVE_HOURS = int(os.getenv('UNRESPONSIVE_HOURS', '2'))
+ENABLE_QUERY = os.getenv('ENABLE_QUERY', 'True')
+
+LOCALISE_TIMESTAMP = bool(os.getenv('LOCALISE_TIMESTAMP',
+                                    'True').upper() == 'TRUE')
+LOGLEVEL = os.getenv('LOGLEVEL', 'info')
+NORMAL_TABLE_COUNT = int(os.getenv('REPORTS_COUNT', '100'))
+LITTLE_TABLE_COUNT = int(os.getenv('LITTLE_TABLE_COUNT', '10'))
+
+TABLE_COUNT_DEF = "10,20,50,100,500"
+TABLE_COUNT_SELECTOR = [int(x) for x in os.getenv('TABLE_COUNT_SELECTOR',
+                                                  TABLE_COUNT_DEF).split(',')]
+
+OFFLINE_MODE = bool(os.getenv('OFFLINE_MODE', 'False').upper() == 'TRUE')
+ENABLE_CATALOG = bool(os.getenv('ENABLE_CATALOG', 'False').upper() == 'TRUE')
+OVERVIEW_FILTER = os.getenv('OVERVIEW_FILTER', None)
+
+GRAPH_FACTS_DEFAULT = ','.join(['architecture', 'clientversion', 'domain',
+                                'lsbcodename', 'lsbdistcodename', 'lsbdistid',
+                                'lsbdistrelease', 'lsbmajdistrelease',
+                                'netmask', 'osfamily', 'puppetversion',
+                                'processorcount'])
+
+GRAPH_FACTS = [x.strip() for x in os.getenv('GRAPH_FACTS',
+                                            GRAPH_FACTS_DEFAULT).split(',')]
+
+
+GRAPH_TYPE = os.getenv('GRAPH_TYPE', 'pie')
+
+# Tuples are hard to express as an environment variable, so here
+# the tupple can be listed as a list of items
+# export INVENTORY_FACTS="Hostname, fqdn, IP Address, ipaddress,.. etc"
+# Define default array of of strings, this code is a bit neater than having
+# a large string
+INVENTORY_FACTS_DEFAULT = ','.join(['Hostname', 'fqdn',
+                                    'IP Address', 'ipaddress',
+                                    'OS', 'lsbdistdescription',
+                                    'Architecture', 'hardwaremodel',
+                                    'Kernel Version', 'kernelrelease',
+                                    'Puppet Version', 'puppetversion'])
+
+# take either input as a list Key, Value, Key, Value,  and conver it to an
+# array: ['Key', 'Value']
+INV_STR = os.getenv('INVENTORY_FACTS', INVENTORY_FACTS_DEFAULT).split(',')
+
+# Take the Array and convert it to a tuple
+INVENTORY_FACTS = [(INV_STR[i].strip(),
+                    INV_STR[i + 1].strip()) for i in range(0, len(INV_STR), 2)]
+
+REFRESH_RATE = int(os.getenv('REFRESH_RATE', '30'))
+
+DAILY_REPORTS_CHART_ENABLED = bool(os.getenv('DAILY_REPORTS_CHART_ENABLED',
+                                             'True').upper() == 'TRUE')
+DAILY_REPORTS_CHART_DAYS = int(os.getenv('DAILY_REPORTS_CHART_DAYS', '8'))

--- a/puppetboard/wsgi.py
+++ b/puppetboard/wsgi.py
@@ -7,8 +7,7 @@ import httplib
 # Puppetboard has the irritating hard requirement that puppetdb
 # must be running and listening before it starts, and will otherwise
 # crash. This makes starting services difficult.
-
-conn = httplib.HTTPConnection('puppetdb', 8080, timeout=10)
+conn = httplib.HTTPConnection(os.getenv('PUPPETDB_HOST', 'puppetdb'), int(os.getenv('PUPPETDB_PORT', '8080')), timeout=10)
 
 while True:
     try:


### PR DESCRIPTION
Voxpupuli's repository has a very good example for setting up Puppetboard under Docker ([docker_settings.py](https://github.com/voxpupuli/puppetboard/blob/master/puppetboard/docker_settings.py)).

This PR uses that example.