### PR TITLE
Adding git binary to r10k container

### DIFF
--- a/r10k/Dockerfile
+++ b/r10k/Dockerfile
@@ -16,6 +16,9 @@ LABEL org.label-schema.vendor="Puppet" \
 
 RUN /opt/puppetlabs/puppet/bin/gem install r10k:"$R10K_VERSION"
 
+RUN ["apt-get","update"]
+RUN ["apt-get","install","git","-y"]
+
 ENTRYPOINT ["/opt/puppetlabs/puppet/bin/r10k"]
 CMD ["help"]
 


### PR DESCRIPTION
Currently, the r10k container does not have a git provider installed.  This is a problem because git is needed for r10k to do its thing.  This change fixes the issue by installing git during container build.

```
$ sudo docker run -v ~/Development/docker/r10k/r10k:/tmp/r10k -v ~/Development/docker/r10k/code:/etc/puppetlabs/code admintome/r10k deploy environment -p -c /tmp/r10k/r10k.yaml
stackadmin@dev:~/Development/docker/r10k$ ls code/
environments
stackadmin@dev:~/Development/docker/r10k$ cd code/environments/
stackadmin@dev:~/Development/docker/r10k/code/environments$ ls
production
stackadmin@dev:~/Development/docker/r10k/code/environments$ cd production/
stackadmin@dev:~/Development/docker/r10k/code/environments/production$ ls
environment.conf  hieradata  modules  Puppetfile  site  site.pp
```

r10k.yaml used:

```
# cat r10k/r10k.yaml 
:cachedir: '/var/cache/r10k'
:git:
  provider: 'shellgit'
:sources:                                                                                                                                                                                                         
  :my-org:
    remote: 'http://gitlab.admintome.local/stackadmin/control-repo-nomad.git'
    basedir: '/etc/puppetlabs/code/environments'
```

Closes: #49 