### PR TITLE
5.4.0 updates fixes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ require 'table_print'
 require_relative 'lib/puppet/dockerfile'
 require_relative 'lib/tableprint/formatters'
 
-include Puppet::Dockerfile
+include Puppet::Dockerfile # rubocop:disable Style/MixinUsage
 
 REPOSITORY = ENV['DOCKER_REPOSITORY'] || 'puppet'
 NO_CACHE = ENV['DOCKER_NO_CACHE'] || false

--- a/Rakefile
+++ b/Rakefile
@@ -176,7 +176,7 @@ end
 
 task :update_base_images do
   desc 'Update base images used in set'
-  ['ubuntu:16.04', 'centos:7', 'alpine:3.4', 'debian:8', 'postgres:9.5.3'].each do |image|
+  ['ubuntu:16.04', 'centos:7', 'alpine:3.4', 'debian:9', 'postgres:9.6.8'].each do |image|
     sh "docker pull #{image}"
   end
 end

--- a/facter/Dockerfile
+++ b/facter/Dockerfile
@@ -1,7 +1,7 @@
 FROM puppet/puppet-agent-ubuntu:5.4.0
-MAINTAINER Puppet Release Team "release@puppet.com"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Facter" \
       org.label-schema.license="Apache-2.0" \

--- a/lib/puppet/dockerfile.rb
+++ b/lib/puppet/dockerfile.rb
@@ -51,7 +51,7 @@ module Puppet # :nodoc:
     def get_value_from_label(image, value)
       labels = JSON.parse(`docker inspect -f "{{json .Config.Labels }}" #{REPOSITORY}/#{image}`)
       labels["#{NAMESPACE}.#{value.tr('_', '-')}"]
-    rescue # rubocop:disable Lint/RescueWithoutErrorClass
+    rescue # rubocop:disable Style/RescueStandardError
       nil
     end
 

--- a/puppet-agent-alpine/Dockerfile
+++ b/puppet-agent-alpine/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.4
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_VERSION="5.4.0" FACTER_VERSION="2.5.1"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Agent (Alpine)" \
       org.label-schema.license="Apache-2.0" \

--- a/puppet-agent-centos/Dockerfile
+++ b/puppet-agent-centos/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos:7
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_AGENT_VERSION="5.4.0"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Agent (Centos)" \
       org.label-schema.license="Apache-2.0" \

--- a/puppet-agent-debian/Dockerfile
+++ b/puppet-agent-debian/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:9
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_AGENT_VERSION="5.4.0" DEBIAN_CODENAME="stretch"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Agent (Debian)" \
       org.label-schema.license="Apache-2.0" \

--- a/puppet-agent-debian/Dockerfile
+++ b/puppet-agent-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8
+FROM debian:9
 MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_AGENT_VERSION="5.4.0" DEBIAN_CODENAME="stretch"

--- a/puppet-agent-ubuntu/Dockerfile
+++ b/puppet-agent-ubuntu/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_AGENT_VERSION="5.4.0" UBUNTU_CODENAME="xenial"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Agent (Ubuntu)" \
       org.label-schema.license="Apache-2.0" \

--- a/puppet-agent/Dockerfile
+++ b/puppet-agent/Dockerfile
@@ -1,7 +1,7 @@
 FROM puppet/puppet-agent-ubuntu:5.4.0
-MAINTAINER Puppet Release Team "release@puppet.com"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Agent" \
       org.label-schema.license="Apache-2.0" \

--- a/puppet-inventory/Dockerfile
+++ b/puppet-inventory/Dockerfile
@@ -1,9 +1,9 @@
 FROM puppet/puppet-agent-ubuntu:5.3.2
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_INVENTORY_VERSION="0.4.0"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Inventory" \
       org.label-schema.license="Apache-2.0" \

--- a/puppetboard/Dockerfile
+++ b/puppetboard/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.4
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_BOARD_VERSION="0.2.2" \
     GUNICORN_VERSION="19.7.1" \
     PUPPETBOARD_PORT="8000"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppetboard" \
       org.label-schema.license="Apache-2.0" \

--- a/puppetboard/Dockerfile
+++ b/puppetboard/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.4
 
 ENV PUPPET_BOARD_VERSION="0.2.2" \
-    GUNICORN_VERSION="19.7.1" \
-    PUPPETBOARD_PORT="8000"
+    GUNICORN_VERSION="19.7.1"
 
 LABEL maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.vendor="Puppet" \
@@ -23,15 +22,15 @@ RUN pip install puppetboard=="$PUPPET_BOARD_VERSION" gunicorn=="$GUNICORN_VERSIO
 
 COPY wsgi.py settings.py /var/www/puppetboard/
 
-EXPOSE $PUPPETBOARD_PORT
+EXPOSE 8000
 
 WORKDIR /var/www/puppetboard
 
-CMD /usr/bin/gunicorn -b 0.0.0.0:${PUPPETBOARD_PORT} --access-logfile=/dev/stdout wsgi:application
+CMD /usr/bin/gunicorn -b 0.0.0.0:8000 --access-logfile=/dev/stdout wsgi:application
 
 # Health check
 HEALTHCHECK --interval=10s --timeout=10s --retries=90 CMD \
-  curl --fail -X GET localhost:${PUPPETBOARD_PORT} \
+  curl --fail -X GET localhost:8000\
   |  grep -q 'Live from PuppetDB' \
   || exit 1
 

--- a/puppetdb-postgres/Dockerfile
+++ b/puppetdb-postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:9.6.8
-MAINTAINER Puppet Release Team "release@puppet.com"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="PostgreSQL instance for PuppetDB" \
       org.label-schema.license="Apache-2.0" \

--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPETDB_VERSION="5.2.0" PUPPET_AGENT_VERSION="5.4.0" DUMB_INIT_VERSION="1.2.1" UBUNTU_CODENAME="xenial" PUPPETDB_DATABASE_CONNECTION="//postgres:5432/puppetdb" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="PuppetDB" \
       org.label-schema.license="Apache-2.0" \

--- a/puppetdb/Dockerfile
+++ b/puppetdb/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Puppet Release Team "release@puppet.com"
 
-ENV PUPPETDB_VERSION="5.2.0" PUPPET_AGENT_VERSION="5.4.0" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETDB_DATABASE_CONNECTION="//postgres:5432/puppetdb" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PUPPETDB_VERSION="5.2.0" PUPPET_AGENT_VERSION="5.4.0" DUMB_INIT_VERSION="1.2.1" UBUNTU_CODENAME="xenial" PUPPETDB_DATABASE_CONNECTION="//postgres:5432/puppetdb" PUPPETDB_USER=puppetdb PUPPETDB_PASSWORD=puppetdb PUPPETDB_JAVA_ARGS="-Djava.net.preferIPv4Stack=true -Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
@@ -22,7 +22,7 @@ RUN apt-get update && \
     dpkg -i dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     rm puppet5-release-"$UBUNTU_CODENAME".deb dumb-init_"$DUMB_INIT_VERSION"_amd64.deb && \
     apt-get update && \
-    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$UBUNTU_CODENAME" puppetdb="$PUPPETDB_VERSION"-1puppetlabs1 && \
+    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1"$UBUNTU_CODENAME" puppetdb="$PUPPETDB_VERSION"-1xenial && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/puppetexplorer/Dockerfile
+++ b/puppetexplorer/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache --update ca-certificates curl wget && \
 
 RUN curl --silent --show-error --fail --location \
       --header "Accept: application/tar+gzip, application/x-gzip, application/octet-stream" -o - \
-      "https://caddyserver.com/download/linux/amd64?plugins=http.prometheus,http.realip" \
+      "https://caddyserver.com/download/linux/amd64?plugins=http.prometheus,http.realip&license=personal" \
     | tar --no-same-owner -C /usr/bin/ -xz caddy \
  && chmod 0755 /usr/bin/caddy \
  && /usr/bin/caddy -version

--- a/puppetexplorer/Dockerfile
+++ b/puppetexplorer/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.4
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_EXPLORER_VERSION="2.0.0"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Explorer" \
       org.label-schema.license="Apache-2.0" \

--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 MAINTAINER Puppet Release Team "release@puppet.com"
 
-ENV PUPPET_SERVER_VERSION="5.2.0" DUMB_INIT_VERSION="1.2.0" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH PUPPET_HEALTHCHECK_ENVIRONMENT="production"
+ENV PUPPET_SERVER_VERSION="5.2.0" DUMB_INIT_VERSION="1.2.1" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 
 LABEL org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \

--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:16.04
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPET_SERVER_VERSION="5.2.0" DUMB_INIT_VERSION="1.2.1" UBUNTU_CODENAME="xenial" PUPPETSERVER_JAVA_ARGS="-Xms256m -Xmx256m" PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH PUPPET_HEALTHCHECK_ENVIRONMENT="production"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Server (No PuppetDB)" \
       org.label-schema.license="Apache-2.0" \

--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.label-schema.vendor="Puppet" \
       com.puppet.dockerfile="/Dockerfile"
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y puppetdb-termini="$PUPPETDB_TERMINUS_VERSION"-1puppetlabs1 && \
+    apt-get install --no-install-recommends -y puppetdb-termini="$PUPPETDB_TERMINUS_VERSION"-1xenial && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/puppetserver/Dockerfile
+++ b/puppetserver/Dockerfile
@@ -1,9 +1,9 @@
 FROM puppet/puppetserver-standalone:5.2.0
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV PUPPETDB_TERMINUS_VERSION="5.2.0"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="Puppet Server" \
       org.label-schema.license="Apache-2.0" \

--- a/r10k/Dockerfile
+++ b/r10k/Dockerfile
@@ -1,9 +1,9 @@
 FROM puppet/puppet-agent-ubuntu:5.4.0
-MAINTAINER Puppet Release Team "release@puppet.com"
 
 ENV R10K_VERSION="2.5.5"
 
-LABEL org.label-schema.vendor="Puppet" \
+LABEL maintainer="Puppet Release Team <release@puppet.com>" \
+      org.label-schema.vendor="Puppet" \
       org.label-schema.url="https://github.com/puppetlabs/puppet-in-docker" \
       org.label-schema.name="r10k" \
       org.label-schema.license="Apache-2.0" \


### PR DESCRIPTION
Update to latest images and packages.
Fix Caddy URL.
Fix various linting and style warnings.

**WARNING:** puppetexplorer now downloads caddy with the personal license as is required (perhaps remove this or add license warning to README).