### PR TITLE
Change autosign default from "true" to autosign.conf path

### DIFF
--- a/puppetserver-standalone/Dockerfile
+++ b/puppetserver-standalone/Dockerfile
@@ -31,7 +31,7 @@ COPY puppetserver /etc/default/puppetserver
 COPY logback.xml /etc/puppetlabs/puppetserver/
 COPY request-logging.xml /etc/puppetlabs/puppetserver/
 
-RUN puppet config set autosign true --section master
+RUN puppet config set autosign /etc/puppetlabs/puppet/autosign.conf --section master
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
Hi again,

having autosign enabled makes it easy to test and play around with Puppet. But the option is considered to be insecure, so I suggest to change it to `/etc/.../autosign.conf`. Especially if someone is using a dockerized puppet in a production-like environment, this would simplify things.

The `autosign.conf` file does not exist by default, so autosign is now turned off. By mounting a autosign.conf whitelist into the container it can be easily enabled in a more secure manner. This was also suggested in #4.

Unfortunately, it's a breaking change for existing setups. :(
