### PR TITLE
SSH in r10k

### DIFF
--- a/r10k/Dockerfile
+++ b/r10k/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.label-schema.maintainer="Puppet Release Team <release@puppet.com>" \
       org.label-schema.dockerfile="/Dockerfile"
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git && \
+    apt-get install --no-install-recommends -y git openssh-client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This commit adds openssh-client to the r10k image so that you can
interact with git via SSH.

Fixes #53